### PR TITLE
Fix error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fp-ts-indexeddb",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fp-ts-indexeddb",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "~27.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fp-ts-indexeddb",
-  "version": "0.1.3",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fp-ts-indexeddb",
-      "version": "0.1.3",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "~27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-indexeddb",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Simple FP-TS based wrapper around indexedDB",
   "main": "dist/lib/index.js",
   "module": "dist/es2015/index.js",

--- a/src/database.ts
+++ b/src/database.ts
@@ -7,8 +7,8 @@ import * as t from 'io-ts';
 import type { ReadonlyRecord } from 'fp-ts/lib/ReadonlyRecord';
 import { pipe } from 'fp-ts/lib/function';
 
-type StoreName = string;
-type Store<StoreC extends t.Mixed> = { key: string, codec: StoreC };
+export type StoreName = string;
+export type Store<StoreC extends t.Mixed> = { key: string, codec: StoreC };
 
 export type DBSchema<StoreC extends t.Mixed> = {
   version: number;
@@ -32,9 +32,9 @@ const findStore = <StoreC extends t.Mixed>(db: DatabaseInfo<StoreC>, storeName: 
   R.lookup(storeName)
 );
 
-const handleRequestError = <A>(req: IDBRequest<A>, fn: (error: O.Option<DOMException>) => void) => {
+const handleRequestError = <A>(req: IDBRequest<A>, fn: (error: DOMException | null) => void) => {
   req.addEventListener('error', function (this: IDBOpenDBRequest) {
-    fn(O.fromNullable(this.error));
+    fn(this.error);
   });
 };
 


### PR DESCRIPTION
Previously errors were getting wrapped in an Option which was causing `[object Object]` error messaging instead of showing the underlying DOMException.