### PR TITLE
Fix schema upgrade handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-indexeddb",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Simple FP-TS based wrapper around indexedDB",
   "main": "dist/lib/index.js",
   "module": "dist/es2015/index.js",

--- a/src/database.ts
+++ b/src/database.ts
@@ -47,7 +47,10 @@ export const open = <StoreC extends t.Mixed>(
     const req = window.indexedDB.open(dbName, schema.version);
     req.onupgradeneeded = () => pipe(
       schema.stores,
-      R.mapWithIndex((storeName: string, v: Store<StoreC>) => req.result.createObjectStore(storeName, { keyPath: v.key }))
+      R.mapWithIndex((storeName: string, v: Store<StoreC>) => {
+        req.result.objectStoreNames.contains(storeName) && req.result.deleteObjectStore(storeName);
+        req.result.createObjectStore(storeName, { keyPath: v.key });
+      })
     );
 
     req.onsuccess = () => resolve({ database: req.result, schema: schema });
@@ -194,3 +197,5 @@ export const clearStore = <StoreC extends t.Mixed>(
     }),
     handlePromiseError,
   );
+
+export const close = <StoreC extends t.Mixed>(db: DatabaseInfo<StoreC>): void => db.database.close();


### PR DESCRIPTION
1. Will delete the current object store when a version changes and replaces it with a new store.
2. Adds close function